### PR TITLE
Add support for API v1.8 features "callback" and "hostPort" to run project

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ table includes the currently implemented options.
 | tags | "smoketest,regression"  | See description above|
 | output | c:\\temp\\reports  | Directory to store reports in.|
 | reportFileName |  N/A | File name for the report. If omitted, the report will get a name based on the test job ID|
+| callback | http://localhost:8080 | The URL, to which the results will be posted|
+| environment | dev | Specify the The target environment for test job. Can not be used with **endpoint**|
+| endpoint | localhost:8080 | The endpoint to be used for HTTP requests sent by this test, in the format host:[port]. Can not be used with **environment**|
 | format | excel | Specify the file type of the report. Currently supported formats are json, junit, excel and pdf. The default format is junit|
 | proxyHost | 172.0.1.10  | Hostname or IP of the server to use as a proxy for outgoing requests (from TestEngine)|
 | proxyPort | 8888  | Port of the proxyHost to contact for outgoing requests (from TestEngine)|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testengine-cli",
-  "version": "1.4.0",
+  "version": "1.8.0",
   "description": "CLI for SmartBear ReadyAPI TestEngine",
   "scripts": {
     "testengine": "bin/testengine.js",


### PR DESCRIPTION
Hello,

I hope this ~~note~~ PR finds you well!

First and foremost, thank you for this tool!  The tool is an integral component in our CI/CD process and we are truly grateful for your efforts.

Second, I apologize in advance for the unsolicited PR.  I did not want to open an issue and I was not able to locate "guidelines for contributing".

Historically one of big differences between TestRunner.bat and TestEngine was the absence of the "endpoint" feature in the  TestEngine API/CLI.  The TestEngine API v1.8 includes the "endpoint" functionality under the guise "hostPort".  Having the aforesaid functionality greatly simplifies my project structure by minimizing duplication (e.g. endpoints/environments).

I also added support for "callback" as it is also a new feature in v1.8.

I thank you again for your efforts and your consideration.

Best Regards,
Will