### PR TITLE
Generate reports even on run failures

### DIFF
--- a/bin/jobs_functions.js
+++ b/bin/jobs_functions.js
@@ -231,7 +231,6 @@ function reportForTestJob(testjobId, outputFolder, fileName, format) {
                     util.printErrorAndExit(`Status code: ${response.status}`);
                 } else {
                     util.output('Report created successfully');
-                    process.exit(0);
                 }
             }).send();
         if (stream) {

--- a/bin/run_functions.js
+++ b/bin/run_functions.js
@@ -499,5 +499,6 @@ function executeProject(filename, project, options) {
                     }
                 }
             }
+        }
     );
 }

--- a/bin/run_functions.js
+++ b/bin/run_functions.js
@@ -482,9 +482,6 @@ function executeProject(filename, project, options) {
                         if (config.showProgress)
                             util.output('');
                         util.output("Result: " + status);
-                        if(status === 'FAILED') {
-                            process.exit(1);
-                        }
                         
                         if ((jobId !== null)
                             && ((status !== 'CANCELED')
@@ -496,8 +493,11 @@ function executeProject(filename, project, options) {
                         }
                     }
                     jobId = null;
+
+                    if(status === 'FAILED') {
+                        process.exit(1);
+                    }
                 }
             }
-        }
     );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testengine-cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "CLI for SmartBear ReadyAPI TestEngine",
   "scripts": {
     "testengine": "bin/testengine.js",


### PR DESCRIPTION
Hello Team,

I hope this PR finds you well!

I love how the CLI now returns an error code for failed runs, however, we would still very much like to generate report artifacts even when the run contains one or more failures.

Thank you, in advance for your time and consideration!

Best Regards,
Will