### PR TITLE
add diagnostics version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ To uninstall, you use the uninstall command.
 
 A fixed license will be deactivated and a floating license will be checked back in to the floating license server. 
 
+## Diagnostics
+
+### Display the TestEngine version
+To check the version of TestEngine, use the diagnostics version command.
+
+`testengine diagnostics version`
+
+Note that `testengine --version` only returns the version of this CLI, not the TestEngine server.
+
 ### Create a diagnostics report
 A diagnostics report is a zip-archive containing information about a running testengine instance that a testengine dev
 needs when troubleshooting testengine. This diagnostics report can be created with the following command.

--- a/bin/diagnostics_functions.js
+++ b/bin/diagnostics_functions.js
@@ -16,6 +16,10 @@ module.exports.dispatcher = function (args) {
             runDiagnostics(options['output'], options['reportFileName']);
             break;
         }
+        case 'version': {
+            runVersion();
+            break;
+        }
         case 'help':
             printModuleHelp();
             break;
@@ -58,9 +62,33 @@ function runDiagnostics(outputFolder, fileName) {
     req.pipe(stream);
 }
 
+function runVersion() {
+    const endPoint = config.server + '/api/v1/version';
+    request.get(endPoint)
+        .auth(config.username, config.password)
+        .accept('application/json')
+        .send()
+        .end((err, result) => {
+            if (err !== null) {
+                if (('status' in err) && ('message' in result.body)) {
+                    util.printErrorAndExit(err['status'] + ': ' + result.body['message']);
+                } else {
+                    util.printErrorAndExit(err);
+                }
+            } else {
+                if ('version' in result.body) {
+                    util.output(result.body.version);
+                } else {
+                    util.printErrorAndExit('Failed to retrieve version');
+                }
+            }
+        });
+}
+
 function printModuleHelp() {
     util.error("Usage: testengine diagnostics <command>");
     util.error("Commands: ");
     util.error("   run [output=<directory>] [reportFileName=<filename>]");
+    util.error("   version");
     util.error("   help");
 }

--- a/test/testScript.js
+++ b/test/testScript.js
@@ -128,7 +128,13 @@ let jobCommands = ['jobs status',
     'jobs report output=output reportFileName=report format=pdf',
     'jobs report output=. reportFileName=report format=noneExisting'];
 
+let diagnosticCommands = [
+    'diagnostics version',
+    'diagnostics help'
+]
+
 runAllCombinations(commands, flags, (command, flag) => runCli(command, flag));
 let testJobId = startJob('successful.xml');
 runAllCombinations(jobCommands, flags, (command, flag) => runCli(command, flag, testJobId));
 runAllCombinations(['jobs cancel'], flags, startSlowJobAndThenRunCli);
+runAllCombinations(diagnosticCommands, ['-H http://localhost:8080'], runCli);


### PR DESCRIPTION
Proposing to add a "diagnostics version" command, to make it easier to identify the version of TestEngine running in situations like CI/CD, without having to download and unzip a larger report. This compliments `testengine --version`, which only tells the end user the version of the CLI, not the server. This can be used for things like debugging a version mismatch with a license server.
